### PR TITLE
Auto-populate fpaths

### DIFF
--- a/DATABASE/DATABASE.py
+++ b/DATABASE/DATABASE.py
@@ -424,6 +424,29 @@ class DATABASEWidget(ScriptedLoadableModuleWidget):
       settings = qt.QSettings()
       settings.setValue('DATABASE/databasePath', path)
       self.refreshDatabaseList()
+      self._prepopulateIngestFields(path)
+      
+  def _prepopulateIngestFields(self, rootDir):
+    atlasDir = os.path.join(rootDir, "atlas")
+
+    templateModel     = os.path.join(atlasDir, "atlas_model.ply")
+    denseCorr         = os.path.join(atlasDir, "atlas_dense_correspondences.mrk.json")
+    sparseLandmarks   = os.path.join(atlasDir, "atlas_sparse_landmarks.mrk.json")
+    populationDir     = os.path.join(rootDir,  "population_correspondences")
+
+    # Only set if the path actually exists, to avoid misleading red/invalid state
+    if os.path.isfile(templateModel):
+        self.ssmTemplateModelSelector.setCurrentPath(templateModel)
+    if os.path.isfile(denseCorr):
+        self.ssmTemplateLandmarksSelector.setCurrentPath(denseCorr)
+    if os.path.isfile(sparseLandmarks):
+        self.ssmSparseLandmarksSelector.setCurrentPath(sparseLandmarks)
+    if os.path.isdir(populationDir):
+        self.ssmPopulationDirSelector.setCurrentPath(populationDir)
+
+    self.ssmNameEditor.setText("atlas_db")
+
+    self.onSelect()
 
   def refreshDatabaseList(self):
     self.databaseListWidget.clear()

--- a/DATABASE/DATABASE.py
+++ b/DATABASE/DATABASE.py
@@ -444,7 +444,7 @@ class DATABASEWidget(ScriptedLoadableModuleWidget):
     if os.path.isdir(populationDir):
         self.ssmPopulationDirSelector.setCurrentPath(populationDir)
 
-    self.ssmNameEditor.setText("atlas_db")
+    self.ssmNameEditor.setText("")
 
     self.onSelect()
 

--- a/PREDICT/PREDICT.py
+++ b/PREDICT/PREDICT.py
@@ -275,7 +275,7 @@ class PREDICTWidget(ScriptedLoadableModuleWidget):
     self.sourceModelSelector            = self._make_selector(["vtkMRMLModelNode"]) ; singleL.addRow("Template model:", self.sourceModelSelector)
     self.sourceFiducialSelector         = self._make_selector(["vtkMRMLMarkupsFiducialNode"]) ; singleL.addRow("Template Correspondences:", self.sourceFiducialSelector)
     self.sourceSparseFiducialSelector   = self._make_selector(["vtkMRMLMarkupsFiducialNode"]) ; singleL.addRow("Template Landmarks:", self.sourceSparseFiducialSelector)
-    self.targetModelSelector            = self._make_selector(["vtkMRMLModelNode"]) ; singleL.addRow("Target model:", self.targetModelSelector)
+    self.targetModelSelector            = self._make_selector(["vtkMRMLModelNode"], none=True) ; singleL.addRow("Target model:", self.targetModelSelector)
     self.ssmTableSelector               = self._make_selector(["vtkMRMLTableNode"], attr_key="ssm_eigenvalues", attr_val=None, tooltip="If you have an SSM table loaded, select it here to use PCA-CPD.") ; singleL.addRow("SSM Data Table:", self.ssmTableSelector)
     self.subsampleButton=qt.QPushButton("1) Subsample source/target"); self.subsampleButton.enabled=False; singleL.addRow(self.subsampleButton)
     self.subsampleInfo=qt.QPlainTextEdit(); self.subsampleInfo.setPlaceholderText("Subsampling information"); self.subsampleInfo.setReadOnly(True); singleL.addRow(self.subsampleInfo)
@@ -383,6 +383,7 @@ class PREDICTWidget(ScriptedLoadableModuleWidget):
     self.optimizeButton.clicked.connect(self.onOptimize)
 
     self.onSelect(); self.onSelectMultiProcess(); self._enable_optimize(); self.parameterDictionary=self._read_params()
+    self._set_default_nodes()
     self.layout.addStretch(1)
 
   # ----- Small helpers -----
@@ -474,6 +475,31 @@ class PREDICTWidget(ScriptedLoadableModuleWidget):
     if not shNode: return
     if getattr(self, "cloneFolderItemID", None): shNode.RemoveItem(self.cloneFolderItemID)
     self.cloneFolderItemID = None
+
+  def _find_node(self, node_class, substring):
+    col = slicer.mrmlScene.GetNodesByClass(node_class)
+    for i in range(col.GetNumberOfItems()):
+        node = col.GetItemAsObject(i)
+        name = node.GetName() or ""
+        if substring.lower() in name.lower():
+            return node
+    return None
+
+  def _set_default_nodes(self):
+    sparse_lm = self._find_node("vtkMRMLMarkupsFiducialNode", "template_sparse_landmarks")
+    if sparse_lm:
+        self.sourceSparseFiducialSelector.setCurrentNode(sparse_lm)
+        self.sourceSparseFiducialMultiSelector.setCurrentNode(sparse_lm)
+        self.d2sourceSparseFiducialSelector.setCurrentNode(sparse_lm)
+
+    ssm_table = self._find_node("vtkMRMLTableNode", "ssm_data")
+    if ssm_table:
+        self.ssmTableSelector.setCurrentNode(ssm_table)
+        self.ssmTableMultiSelector.setCurrentNode(ssm_table)
+        self.d2ssmTableSelector.setCurrentNode(ssm_table)
+
+    self.targetModelSelector.setCurrentNode(None)
+    self.d2targetModelSelector.setCurrentNode(None)
 
   def _hideInputNodes(self):
     for selector in (self.sourceModelSelector, self.sourceFiducialSelector, self.sourceSparseFiducialSelector, self.targetModelSelector):

--- a/SEGMENTATION/SEGMENTATION.py
+++ b/SEGMENTATION/SEGMENTATION.py
@@ -40,9 +40,9 @@ class SEGMENTATIONWidget(ScriptedLoadableModuleWidget):
     basic = ctk.ctkCollapsibleButton(); basic.text = "Required Inputs"; basic.collapsed = False
     fb = qt.QFormLayout(basic); f.addRow(basic)
     self.meshDir=qt.QLineEdit(); b1=qt.QToolButton(); b1.text="…"; b1.clicked.connect(lambda:self._browse(self.meshDir))
-    h1=qt.QHBoxLayout(); h1.addWidget(self.meshDir); h1.addWidget(b1); fb.addRow("Meshes folder:",h1)
+    h1=qt.QHBoxLayout(); h1.addWidget(self.meshDir); h1.addWidget(b1); fb.addRow("Aligned Models folder:",h1)
     self.mrkDir=qt.QLineEdit(); b2=qt.QToolButton(); b2.text="…"; b2.clicked.connect(lambda:self._browse(self.mrkDir))
-    h2=qt.QHBoxLayout(); h2.addWidget(self.mrkDir); h2.addWidget(b2); fb.addRow("Dense Correspondences (.mrk.json) Folder:",h2)
+    h2=qt.QHBoxLayout(); h2.addWidget(self.mrkDir); h2.addWidget(b2); fb.addRow("Population Correspondences (.mrk.json) folder:",h2)
     self.outDir=qt.QLineEdit(); b3=qt.QToolButton(); b3.text="…"; b3.clicked.connect(lambda:self._browse(self.outDir))
     h3=qt.QHBoxLayout(); h3.addWidget(self.outDir); h3.addWidget(b3); fb.addRow("Output folder:",h3)
 


### PR DESCRIPTION
## Auto-populate file paths for DATABASE Module
Open BUILDER output folder as 1) Database Library `Database Location`, then file paths auto-populate under 2) Ingest New SSM. 
<img width="698" height="476" alt="db" src="https://github.com/user-attachments/assets/aae0708f-d7a9-4e2e-908c-5e2b72ac9ddb" />

## Auto-populate file paths for PREDICT Module
After ingesting SSM in DATABASE, file paths auto-populate for Single Run, Batch, and Template Optimization tabs.
<img width="695" height="253" alt="predict_default_fns" src="https://github.com/user-attachments/assets/c7ac3702-2a34-46e8-a964-936fb25c49b3" />
<img width="693" height="416" alt="predict_default_fns2" src="https://github.com/user-attachments/assets/cb7e86ab-2abf-411d-8d6f-610aa280eb60" />
<img width="704" height="325" alt="predict_default_fns3" src="https://github.com/user-attachments/assets/48d09b27-1a8d-48d0-a19e-40f0a899b489" />


## Rename Input Form Fields in SEGMENTATION
Rename form fields from `Meshes folder` -> `Aligned Models Folder` and from `Dense correspondences (.mrk.json) folder` to `Population correspondences (.mrk.json) folder` for clear, consistent names throughout modules.
<img width="700" height="257" alt="seg_inputs" src="https://github.com/user-attachments/assets/29cbfced-c2c6-47d4-8cfa-1d33abee1251" />