### PR TITLE
Update publication URLs after repository rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,13 @@ set(EXTENSION_ICONURL "https://raw.githubusercontent.com/agporto/SlicerATLAS/mai
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/agporto/SlicerATLAS/main/tutorial/images/20.png")
 set(EXTENSION_DEPENDS "")
 
-find_package(S
+find_package(Slicer REQUIRED)
+include(${Slicer_USE_FILE})
+
+add_subdirectory(PREDICT)
+add_subdirectory(BUILDER)
+add_subdirectory(DATABASE)
+add_subdirectory(SEGMENTATION)
+
+include(${Slicer_EXTENSION_GENERATE_CONFIG})
+include(${Slicer_EXTENSION_CPACK})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,21 +3,12 @@ cmake_minimum_required(VERSION 3.5)
 project(ATLAS)
 
 # Extension metadata displayed in the Slicer Extensions Manager.
-set(EXTENSION_HOMEPAGE "https://github.com/agporto/ATLAS")
+set(EXTENSION_HOMEPAGE "https://github.com/agporto/SlicerATLAS")
 set(EXTENSION_CATEGORY "Registration")
 set(EXTENSION_CONTRIBUTORS "Arthur Porto (Florida Museum of Natural History, University of Florida)")
 set(EXTENSION_DESCRIPTION "ATLAS provides workflows for constructing 3D anatomical atlases and statistical shape models and for automatically transferring landmarks to new surface models. It combines rigid surface registration, shape-model-guided deformable registration, and optional surface projection.")
-set(EXTENSION_ICONURL "https://raw.githubusercontent.com/agporto/ATLAS/main/PREDICT/Resources/Icons/PREDICT.png")
-set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/agporto/ATLAS/main/tutorial/images/20.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/agporto/SlicerATLAS/main/PREDICT/Resources/Icons/PREDICT.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/agporto/SlicerATLAS/main/tutorial/images/20.png")
 set(EXTENSION_DEPENDS "")
 
-find_package(Slicer REQUIRED)
-include(${Slicer_USE_FILE})
-
-add_subdirectory(PREDICT)
-add_subdirectory(BUILDER)
-add_subdirectory(DATABASE)
-add_subdirectory(SEGMENTATION)
-
-include(${Slicer_EXTENSION_GENERATE_CONFIG})
-include(${Slicer_EXTENSION_CPACK})
+find_package(S

--- a/Docs/ExtensionCatalogSubmission.md
+++ b/Docs/ExtensionCatalogSubmission.md
@@ -6,7 +6,7 @@ ATLAS is prepared for an initial Tier 1 submission to the Slicer ExtensionsIndex
 
 Before opening the ExtensionsIndex pull request:
 
-- Add the GitHub topic `3d-slicer-extension` to the ATLAS repository.
+- Add the GitHub topic `3d-slicer-extension` to the SlicerATLAS repository.
 - Keep `SlicerMorph` documented as a complementary extension, not a build dependency.
 - Confirm that the raw icon and screenshot URLs in the top-level `CMakeLists.txt` resolve from the `main` branch.
 - Merge this publication-preparation branch into `main`.
@@ -17,6 +17,7 @@ Copy `ExtensionsIndex/ATLAS.json` into the root of a fork of `Slicer/ExtensionsI
 
 The entry intentionally uses:
 
+- Repository: `https://github.com/agporto/SlicerATLAS.git`
 - Category: `Registration`
 - Revision: `main`
 - Build dependencies: none
@@ -38,8 +39,7 @@ No SlicerMorph dependency or bundled test dataset is required for the initial Ti
 
 State that:
 
-- ATLAS is an established software name, which is why the repository is not named `SlicerATLAS`.
+- The repository follows the recommended `Slicer+ExtensionName` naming convention while the extension remains displayed as ATLAS in Slicer.
 - The extension operates locally and does not upload user data.
 - Python dependencies are obtained from the configured Python package index with explicit user approval.
-- No related patents are known.
 - The source is released under the BSD 2-Clause License.

--- a/ExtensionsIndex/ATLAS.json
+++ b/ExtensionsIndex/ATLAS.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/Slicer/Slicer/main/Schemas/slicer-extension-catalog-entry-schema-v1.0.1.json#",
   "category": "Registration",
-  "scm_url": "https://github.com/agporto/ATLAS.git",
+  "scm_url": "https://github.com/agporto/SlicerATLAS.git",
   "scm_revision": "main",
   "scm_type": "git",
   "build_dependencies": [],

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="tutorial/README.md"><strong>Tutorial</strong></a> ·
-  <a href="https://github.com/agporto/ATLAS/issues"><strong>Issues</strong></a> ·
+  <a href="https://github.com/agporto/SlicerATLAS/issues"><strong>Issues</strong></a> ·
   <a href="https://discourse.slicer.org/"><strong>Slicer Forum</strong></a>
 </p>
 
@@ -47,7 +47,7 @@ Once listed in the official Slicer Extensions Catalog:
 ### Developer installation
 
 ```bash
-git clone https://github.com/agporto/ATLAS.git
+git clone https://github.com/agporto/SlicerATLAS.git
 ```
 
 In Slicer, open **Developer Tools > Extension Wizard**, choose **Select Extension**, and select the cloned repository folder.
@@ -119,7 +119,7 @@ The Pose-marginalized EM backend is optional. The established FPFH + RANSAC temp
 ## Documentation and support
 
 - [ATLAS tutorial](tutorial/README.md)
-- [Issue tracker](https://github.com/agporto/ATLAS/issues)
+- [Issue tracker](https://github.com/agporto/SlicerATLAS/issues)
 - [3D Slicer documentation](https://slicer.readthedocs.io/)
 - [SlicerMorph tutorials](https://github.com/SlicerMorph/Tutorials)
 - [Slicer Forum](https://discourse.slicer.org/) — use the *Morphology* or *Extensions* categories
@@ -143,7 +143,7 @@ Until the formal ATLAS publication is available, cite the software repository:
 
 ```text
 Porto, A. ATLAS: Automated Template-based Landmark Alignment System.
-https://github.com/agporto/ATLAS
+https://github.com/agporto/SlicerATLAS
 ```
 
 Please also cite the methods and software used by the relevant workflow, including 3D Slicer, SlicerMorph when used, DeCA for related dense-correspondence analyses, and the `biocpd` or `tiny3d` documentation as appropriate.


### PR DESCRIPTION
## Summary

Updates ATLAS publication metadata after renaming the repository from `agporto/ATLAS` to `agporto/SlicerATLAS`.

### Changes

- updates the extension homepage, icon, and screenshot URLs in `CMakeLists.txt`
- updates `scm_url` in `ExtensionsIndex/ATLAS.json`
- updates clone, issue tracker, and citation links in the README
- updates the ExtensionsIndex submission notes for the new repository name
- removes the now-obsolete repository-name and patent notes from the internal submission guide

The extension remains displayed as **ATLAS** within 3D Slicer.